### PR TITLE
fixed order age groups

### DIFF
--- a/Code/life_expectancy_functions.R
+++ b/Code/life_expectancy_functions.R
@@ -107,9 +107,9 @@ cause_of_death_decomp <- function(life.table1, life.table2, decomp.table,
 make_dataset_cod_plot <- function(cod.decomp.table, age.groups, cause.of.death, sign.var, decomp.var, decomp.var.prop) {
   cod.decomp.table["group"] <- interaction(cod.decomp.table[[age.groups]], cod.decomp.table[[sign.var]], sep = ".")
 
-  cod.decomp.table <- cod.decomp.table[order(cod.decomp.table[age.groups], 
-                                             cod.decomp.table[sign.var], 
-                                             cod.decomp.table[cause.of.death]), ]
+  cod.decomp.table <- cod.decomp.table[order(cod.decomp.table[[age.groups]], 
+                                             cod.decomp.table[[sign.var]], 
+                                             cod.decomp.table[[cause.of.death]]), ]
   
   cod.decomp.table$start <- 0
   cod.decomp.table$finish <- cod.decomp.table[[decomp.var]] #C_xi


### PR DESCRIPTION
Fixes the display problem with the order of the age groupings in the shiny app. Don't quite understand, but need double square brackets in the revised code to actually order by cause.of.death. In our case, "cause of death" is actually age groups..confusing i know. 